### PR TITLE
Add environment variable MAX_PROCESS_PER_AGENT

### DIFF
--- a/lib/knapsack/runners/rspec_runner.rb
+++ b/lib/knapsack/runners/rspec_runner.rb
@@ -51,7 +51,9 @@ module Knapsack
         # Default is 2 agents per instance
         default_agent_count = 2
         num_agents = (ENV['NUM_AGENTS_PER_INSTANCE'] || default_agent_count).to_i
-        num = (ncpu.to_f / (num_agents == 0 ? default_agent_count : num_agents)).ceil
+        num = (ncpu.to_f / (num_agents < 1 ? default_agent_count : num_agents)).ceil
+        max = ENV['MAX_PROCESS_PER_AGENT'].to_i
+        num = max if max > 0 && num > max
         num <= 1 ? 1 : num
       end
 

--- a/spec/knapsack/runners/rspec_runner_spec.rb
+++ b/spec/knapsack/runners/rspec_runner_spec.rb
@@ -1,0 +1,74 @@
+describe Knapsack::Runners::RSpecRunner do
+  describe '#max_process_count' do
+    before { allow(Knapsack::Runners::RSpecRunner).to receive(:ncpu).and_return(8) }
+    after do
+      ENV['MAX_PROCESS_PER_AGENT'] = nil
+      ENV['NUM_AGENTS_PER_INSTANCE'] = nil
+    end
+    subject { Knapsack::Runners::RSpecRunner.max_process_count }
+
+    it { should eql 4 }
+
+    describe 'MAX_PROCESS_PER_AGENT' do
+      context 'max per agent is less than the calculated number' do
+        before { ENV['MAX_PROCESS_PER_AGENT'] = '3' }
+
+        it { should eql 3 }
+      end
+
+      context 'max per agent is more than the calculated number' do
+        before { ENV['MAX_PROCESS_PER_AGENT'] = '5' }
+
+        it { should eql 4 }
+
+        context 'max per agent is 1' do
+          before { ENV['MAX_PROCESS_PER_AGENT'] = '1' }
+
+          it { should eql 1 }
+        end
+      end
+
+      context 'max per agent is 0' do
+        before { ENV['MAX_PROCESS_PER_AGENT'] = '0' }
+
+        it { should eql 4 }
+      end
+
+      context 'max per agent is -1' do
+        before { ENV['MAX_PROCESS_PER_AGENT'] = '-1' }
+
+        it { should eql 4 }
+      end
+    end
+
+    describe 'NUM_AGENTS_PER_INSTANCE' do
+      before { ENV['NUM_AGENTS_PER_INSTANCE'] = '3' }
+
+      it { should eql 3 }
+
+      context 'number of agents is bigger than number of CPUs' do
+        before { ENV['NUM_AGENTS_PER_INSTANCE'] = '10' }
+
+        it { should eql 1 }
+      end
+
+      context 'number of agents is 1' do
+        before { ENV['NUM_AGENTS_PER_INSTANCE'] = '1' }
+
+        it { should eql 8 }
+      end
+
+      context 'number of agents is 0' do
+        before { ENV['NUM_AGENTS_PER_INSTANCE'] = '0' }
+
+        it { should eql 4 }
+      end
+
+      context 'number of agents is -1' do
+        before { ENV['NUM_AGENTS_PER_INSTANCE'] = '-1' }
+
+        it { should eql 4 }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows us to set the maximum number of process per agent on an instance. So that, for example, if our instance has 8 cores and 2 agents, each agent will run 4 parallel processes and total to 8 parallel processes. That may take too much memory.

Instead, we can set MAX_PROCESS_PER_AGENT to 3. This way, we run 2 x 3 = 6 total parallel processes, which should use less memory.

- [x] @tjackiw 